### PR TITLE
fix: suppress warning if `pathMatch` is empty (#3081)

### DIFF
--- a/src/util/params.js
+++ b/src/util/params.js
@@ -25,7 +25,8 @@ export function fillParams (
     return filler(params, { pretty: true })
   } catch (e) {
     if (process.env.NODE_ENV !== 'production') {
-      warn(false, `missing param for ${routeMsg}: ${e.message}`)
+      // Fix #3072 no warn if `pathMatch` is string
+      warn(typeof params.pathMatch === 'string', `missing param for ${routeMsg}: ${e.message}`)
     }
     return ''
   } finally {

--- a/test/unit/specs/create-matcher.spec.js
+++ b/test/unit/specs/create-matcher.spec.js
@@ -71,6 +71,15 @@ describe('Creating Matcher', function () {
     expect(path).toEqual('/error/some')
   })
 
+  it('matches named catch-all route with empty pathMath param without warning', function () {
+    process.env.NODE_ENV = 'development'
+    match(
+      { name: 'notFound', params: { pathMatch: '' }},
+      routes[0]
+    )
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
   it('matches asterisk routes with a default param name', function () {
     const { params } = match({ path: '/not-found' }, routes[0])
     expect(params).toEqual({ pathMatch: '/not-found' })


### PR DESCRIPTION
Fix #3072

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
