### PR TITLE
fix: correctly calculate `path` when `pathMatch` is empty string (#3111)

### DIFF
--- a/src/util/params.js
+++ b/src/util/params.js
@@ -20,7 +20,8 @@ export function fillParams (
       (regexpCompileCache[path] = Regexp.compile(path))
 
     // Fix #2505 resolving asterisk routes { name: 'not-found', params: { pathMatch: '/not-found' }}
-    if (params.pathMatch) params[0] = params.pathMatch
+    // and fix #3106 so that you can work with location descriptor object having params.pathMatch equal to empty string
+    if (typeof params.pathMatch === 'string') params[0] = params.pathMatch
 
     return filler(params, { pretty: true })
   } catch (e) {

--- a/test/unit/specs/create-matcher.spec.js
+++ b/test/unit/specs/create-matcher.spec.js
@@ -84,4 +84,20 @@ describe('Creating Matcher', function () {
     const { params } = match({ path: '/not-found' }, routes[0])
     expect(params).toEqual({ pathMatch: '/not-found' })
   })
+
+  it('allows an empty pathMatch', function () {
+    process.env.NODE_ENV = 'development'
+    const pathForErrorRoute = match(
+      { name: 'error', params: { pathMatch: '' }},
+      routes[0]
+    ).path
+    const pathForNotFoundRoute = match(
+      { name: 'notFound', params: { pathMatch: '' }},
+      routes[0]
+    ).path
+
+    expect(console.warn).not.toHaveBeenCalled()
+    expect(pathForErrorRoute).toEqual('/error/')
+    expect(pathForNotFoundRoute).toEqual('/')
+  })
 })


### PR DESCRIPTION
fix #3106

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
