### PR TITLE
fix(ts): add null to Route.name (#3117)

### DIFF
--- a/types/router.d.ts
+++ b/types/router.d.ts
@@ -134,7 +134,7 @@ export interface Location {
 
 export interface Route {
   path: string
-  name?: string
+  name?: string | null
   hash: string
   query: Dictionary<string | (string | null)[]>
   params: Dictionary<string>

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -113,7 +113,7 @@ const mode: string = router.mode
 
 const route: Route = router.currentRoute
 const path: string = route.path
-const name: string | undefined = route.name
+const name: string | undefined | null = route.name
 const hash: string = route.hash
 const query: string | (string | null)[] | null = route.query['foo']
 const params: string = route.params['bar']
@@ -128,7 +128,7 @@ matched.forEach(m => {
   [key: string]: ComponentOptions<Vue> | typeof Vue | AsyncComponent
   } = m.components
   const instances: { [key: string]: Vue } = m.instances
-  const name: string | undefined = m.name
+  const name: string | undefined | null = m.name
   const parant: RouteRecord | undefined = m.parent
   const redirect: RedirectOption | undefined = m.redirect
 })


### PR DESCRIPTION
* Update type of Route.name

On very first load, `name` is `null`, not `string` or `undefined`. This means that either the passed route is wrong, or the type is incorrect.

* fix(tests): fix type test

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
